### PR TITLE
Bugfix for Elliptic Curve serialization

### DIFF
--- a/pyhpke/keys/ec_key.py
+++ b/pyhpke/keys/ec_key.py
@@ -93,7 +93,7 @@ class ECKey(KEMKeyInterface):
     def to_private_bytes(self) -> bytes:
         if self._is_public:
             raise ValueError("The key is public")
-        private_value = self._key.private_numbers().private_value # type: int
+        private_value = self._key.private_numbers().private_value  # type: int
         return private_value.to_bytes(self._key.key_size, "big")
 
     def to_public_bytes(self) -> bytes:

--- a/pyhpke/keys/ec_key.py
+++ b/pyhpke/keys/ec_key.py
@@ -5,10 +5,7 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePrivateKey,
     EllipticCurvePublicKey,
 )
-from cryptography.hazmat.primitives.serialization import (
-    Encoding,
-    PublicFormat,
-)
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from ..consts import HPKE_SUPPORTED_JWK_EC_CRVS
 from ..kem_key_interface import KEMKeyInterface

--- a/pyhpke/keys/ec_key.py
+++ b/pyhpke/keys/ec_key.py
@@ -7,8 +7,6 @@ from cryptography.hazmat.primitives.asymmetric.ec import (
 )
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
-    NoEncryption,
-    PrivateFormat,
     PublicFormat,
 )
 

--- a/pyhpke/keys/ec_key.py
+++ b/pyhpke/keys/ec_key.py
@@ -93,7 +93,8 @@ class ECKey(KEMKeyInterface):
     def to_private_bytes(self) -> bytes:
         if self._is_public:
             raise ValueError("The key is public")
-        return self._key.private_bytes(Encoding.DER, PrivateFormat.PKCS8, NoEncryption())
+        private_value = self._key.private_numbers().private_value # type: int
+        return private_value.to_bytes(self._key.key_size, "big")
 
     def to_public_bytes(self) -> bytes:
         """


### PR DESCRIPTION
by mistake i serialized Elliptic Curve Private Keys as DER Encoding. Instead the private_numbers().private_value should be serialized.