### PR TITLE
chore(deps): allow cryptography 50 and 51

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A Python implementation of HPKE."
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "cryptography>=42.0.1,<50",
+    "cryptography>=42.0.1,<52",
 ]
 authors = [{ name = "Ajitomi Daisuke", email = "dajiaji@gmail.com" }]
 license = "MIT"


### PR DESCRIPTION
Widen the upper bound from `<50` to `<52` so the package installs alongside the current cryptography releases.